### PR TITLE
add ModifyUsers and DefaultAccountFamily use cases

### DIFF
--- a/Onboarding/DefaultAccountFamily/README.md
+++ b/Onboarding/DefaultAccountFamily/README.md
@@ -1,0 +1,30 @@
+# Default Account Family with the CloudCheckr API
+
+---
+
+## Steps to Run
+
+1. Install python 3. https://www.python.org/downloads/
+2. Install requests and logging python libraries with pip3
+3. Log into CloudCheckr and create an Admin API access key at Admin Functions >> Admin API Key, https://app.cloudcheckr.com/Project/GlobalApiCredentials
+4. Run python3 default_account_family.py <cloudcheckr-admin-api-key>
+
+---
+
+## How the program works
+
+Uses [get_account_family_v2](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#get_account_family_v2) API call to get account data for modify_account_family API call.
+
+Uses [modify_account_family](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#modify_account_family) API call to add all unmapped accounts to default account family.
+
+The payer project id is set at line 86. 
+
+The default account familty is set at line 87.
+
+You can view CloudCheckr Account Families through the UI at Cost >> AWS Partner Tools >> Configure >> Account Families.
+
+---
+
+## Assumptions
+
+1. The environment https://api.cloudcheckr.com is being used. This can be adjusted on line 83 if required.

--- a/Onboarding/DefaultAccountFamily/default_account_family.py
+++ b/Onboarding/DefaultAccountFamily/default_account_family.py
@@ -64,7 +64,7 @@ def modify_account_family(admin_api_key, env, project_id, default_account_family
 def validate_env(env):
     """
     Validates enviroment. By default, it checks for api, eu, au, gov and qa.
-    If you are using a standalone environment, then you must add it to the environments lsit
+    If you are using a standalone environment, then you must add it to the environments list
     """
 
     enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]

--- a/Onboarding/DefaultAccountFamily/default_account_family.py
+++ b/Onboarding/DefaultAccountFamily/default_account_family.py
@@ -70,7 +70,7 @@ def validate_env(env):
     enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]
 
     if env not in enviroments:
-        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the check_invalid_env function.")
+        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the validate_env function.")
 
 
 def main():

--- a/Onboarding/DefaultAccountFamily/default_account_family.py
+++ b/Onboarding/DefaultAccountFamily/default_account_family.py
@@ -1,0 +1,93 @@
+import requests
+import json
+import sys
+import logging
+logging.basicConfig(filename='logging_for_default_account_family.log',level=logging.INFO)
+
+"""
+This python script is used to add all unmapped accounts to a single account family
+python3 default_account_family.py 0000000000000000000000000000000000000000000000000000000000000000
+"""
+
+def log_information(log_string):
+    logging.info(log_string)
+    print(log_string)
+
+
+def get_accounts(admin_api_key, env, project_id, default_account_family):
+    """
+    Uses admin API key to get account data for modify_account_family API call
+    """
+    
+    half_url = f"{env}/api/billing.json/get_account_family_v2"
+    api_parameters = {"use_cc_account_id": project_id}
+    resp = requests.get(half_url, params=api_parameters, headers = {"access_key": admin_api_key})
+    
+    account_families = []
+    existing_accounts = []
+    unmapped_accounts = []
+    accounts = []
+    account_string = []
+
+    if "Code" in resp.json():
+        account_families = resp.json()["AccountFamilies"]
+        for account_familiy in account_families:
+            if account_familiy["Name"] == default_account_family:
+                existing_accounts = account_familiy["Accounts"]
+        unmapped_accounts = resp.json()["UnmappedAccounts"]
+        accounts = existing_accounts + unmapped_accounts
+        for account in accounts:
+            account_string.append(account.split(" ")[0])
+        log_information("Obtained account data")
+    else:
+        log_information("Failed to obtain account data")
+        return
+    
+    return ",".join(account_string)
+    
+
+def modify_account_family(admin_api_key, env, project_id, default_account_family, accounts):
+    """
+    Uses admin API key to add all unmapped accounts to default account family
+    """
+
+    half_url = f"{env}/api/billing.json/modify_account_family"
+    api_parameters = {"use_cc_account_id": project_id, "name": default_account_family, "accounts": accounts}
+    resp = requests.post(half_url, data=json.dumps(api_parameters), headers = {"Content-type": "application/json", "access_key": admin_api_key})
+
+    if "Code" in resp.json():
+        log_information(f"Modified account family: {default_account_family}")
+    else:
+        log_information(f"Falied to modifify account family: {default_account_family}")
+
+
+def validate_env(env):
+    """
+    Validates enviroment. By default, it checks for api, eu, au, gov and qa.
+    If you are using a standalone environment, then you must add it to the environments lsit
+    """
+
+    enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]
+
+    if env not in enviroments:
+        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the check_invalid_env function.")
+
+
+def main():
+    try:
+        admin_api_key = str(sys.argv[1])
+    except IndexError:
+        log_information("Must include admin API key")
+        return
+    
+    env = "https://api.cloudcheckr.com"
+    validate_env(env)
+    
+    project_id = 5
+    default_account_family = "183698509299 (Aaron Gettings)"
+    account_string = get_accounts(admin_api_key, env, project_id, default_account_family)
+    modify_account_family(admin_api_key, env, project_id, default_account_family, account_string)
+
+
+if __name__ == '__main__':
+    main()

--- a/Onboarding/DefaultAccountFamily/logging_for_default_account_family.log
+++ b/Onboarding/DefaultAccountFamily/logging_for_default_account_family.log
@@ -1,0 +1,2 @@
+INFO:root:Obtained account data
+INFO:root:Modified account family: 183698509299 (Aaron Gettings)

--- a/Onboarding/ModifyUsers/README.md
+++ b/Onboarding/ModifyUsers/README.md
@@ -17,9 +17,9 @@ Uses the [get_users_v2](https://success.cloudcheckr.com/article/kr5glkrmon-admin
 
 Uses the [edit_user](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#edit_user) API call to modify users.
 
-The criteria is set at line 31. 
+The criteria is set at line 30. 
 
-The desired result is set at line 45.
+The desired result is set at line 44.
 
 The program is set to modify users with user role, PartnerSysAdmin, to user role, Administrator.
 
@@ -29,4 +29,4 @@ You can view CloudCheckr Users through the UI at Settings >> Users.
 
 ## Assumptions
 
-1. The environment https://api.cloudcheckr.com is being used. This can be adjusted on line 76 if required.
+1. The environment https://api.cloudcheckr.com is being used. This can be adjusted on line 71 if required.

--- a/Onboarding/ModifyUsers/README.md
+++ b/Onboarding/ModifyUsers/README.md
@@ -1,0 +1,32 @@
+# Modify Users with the CloudCheckr API
+
+---
+
+## Steps to Run
+
+1. Install python 3. https://www.python.org/downloads/
+2. Install requests and logging python libraries with pip3
+3. Log into CloudCheckr and create an Admin API access key at Admin Functions >> Admin API Key, https://app.cloudcheckr.com/Project/GlobalApiCredentials
+4. Run python3 modify_users.py <cloudcheckr-admin-api-key>
+
+---
+
+## How the program works
+
+Uses the [get_users_v2](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#get_users_v2) API call to get user data from an environment.
+
+Uses the [edit_user](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#edit_user) API call to modify users.
+
+The criteria is set at line 31. 
+
+The desired result is set at line 45.
+
+The program is set to modify users with user role, PartnerSysAdmin, to user role, Administrator.
+
+You can view CloudCheckr Users through the UI at Settings >> Users.
+
+---
+
+## Assumptions
+
+1. The environment https://api.cloudcheckr.com is being used. This can be adjusted on line 76 if required.

--- a/Onboarding/ModifyUsers/README.md
+++ b/Onboarding/ModifyUsers/README.md
@@ -13,9 +13,9 @@
 
 ## How the program works
 
-Uses the [get_users_v2](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#get_users_v2) API call to get user data from an environment.
+Uses [get_users_v2](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#get_users_v2) API call to get user data from the tenant.
 
-Uses the [edit_user](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#edit_user) API call to modify users.
+Uses [edit_user](https://success.cloudcheckr.com/article/kr5glkrmon-admin-api-reference-guide#edit_user) API call to modify users as per the criteria and desired result.
 
 The criteria is set at line 30. 
 

--- a/Onboarding/ModifyUsers/logging_for_modify_users.log
+++ b/Onboarding/ModifyUsers/logging_for_modify_users.log
@@ -1,0 +1,1 @@
+INFO:root:Modified user with email: brett.gadberry+psa@cloudcheckr.com

--- a/Onboarding/ModifyUsers/modify_users.py
+++ b/Onboarding/ModifyUsers/modify_users.py
@@ -16,7 +16,7 @@ def log_information(log_string):
 
 def get_users_v2(admin_api_key, env):
     """
-    Uses admin_api_key to get user data
+    Uses admin API key to get user data
     """
     
     half_url = f"{env}/api/account.json/get_users_v2"
@@ -24,6 +24,7 @@ def get_users_v2(admin_api_key, env):
     resp = requests.get(half_url, params=api_parameters, headers = {"access_key": admin_api_key})
     
     users = []
+
     if "user_permissions" in resp.json():
         user_data = resp.json()["user_permissions"]
         for user in user_data:
@@ -37,7 +38,7 @@ def get_users_v2(admin_api_key, env):
 
 def edit_user(admin_api_key, env, user):
     """
-    Uses admin_api_key to modify user
+    Uses admin API key to modify user
     """
     
     half_url = f"{env}/api/account.json/edit_user"

--- a/Onboarding/ModifyUsers/modify_users.py
+++ b/Onboarding/ModifyUsers/modify_users.py
@@ -62,6 +62,7 @@ def check_invalid_env(env):
     if env not in Enviroments:
         log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the check_invalid_env function.")
 
+
 def main():
     try:
         admin_api_key = str(sys.argv[1])

--- a/Onboarding/ModifyUsers/modify_users.py
+++ b/Onboarding/ModifyUsers/modify_users.py
@@ -1,0 +1,85 @@
+import requests
+import json
+import sys
+import logging
+logging.basicConfig(filename='logging_for_modify_users.log',level=logging.INFO)
+
+"""
+This python script is used to modify users based on a specified criteria and desired result
+python3 modify_users.py 0000000000000000000000000000000000000000000000000000000000000000
+"""
+
+def log_information(log_string):
+    logging.info(log_string)
+    print(log_string)
+
+
+def get_users_v2(admin_api_key):
+    """
+    Uses admin_api_key to get user data
+    """
+    
+    half_url = "https://api.cloudcheckr.com/api/account.json/get_users_v2"
+    api_parameters = {}
+    resp = requests.get(half_url, params=api_parameters, headers = {"access_key": admin_api_key})
+    data = resp.json()
+    
+    users = []
+    if "user_permissions" in data:
+        user_data = data["user_permissions"]
+        for user in user_data:
+            if user["role"] == "PartnerSysAdmin":
+                users.append(user["email"])
+    else:
+        log_information("Unable to obtain user data")
+    
+    return users
+
+
+def edit_user(admin_api_key, user):
+    """
+    Uses admin_api_key and get_users_v2 result to modify users
+    """
+    
+    half_url = "https://api.cloudcheckr.com/api/account.json/edit_user"
+    api_parameters = {"email": user, "role": "Administrator"}
+    resp = requests.post(half_url, data=json.dumps(api_parameters), headers = {"Content-type": "application/json", "access_key": admin_api_key})
+    output_data = resp.json()
+
+    if "Code" in output_data:
+        log_information(f"Modified user with email: {user}")
+    else:
+        log_information(f"Failed to modify user with email: {user}")
+
+
+def check_valid_env(env):
+    """
+    Checks for a valid enviroment. Currently, it will only check for api, eu, au, gov, or qa.
+    If you are using a standalone environment, then you MUST add it to this function
+    """
+
+    Enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]
+
+    if not(env in Enviroments):
+        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the check_invalid_env function.")
+        return True
+    return False
+
+
+def main():
+    try:
+        admin_api_key = str(sys.argv[1])
+    except IndexError:
+        log_information("Must include admin API key of environemt that you want to modify")
+        return
+
+    env = "https://api.cloudcheckr.com"
+    check_valid_env(env)
+
+    users = get_users_v2(admin_api_key)
+    for user in users:
+        edit_user(admin_api_key, user)
+
+
+if __name__ == '__main__':
+    main()

--- a/Onboarding/ModifyUsers/modify_users.py
+++ b/Onboarding/ModifyUsers/modify_users.py
@@ -51,16 +51,16 @@ def edit_user(admin_api_key, env, user):
         log_information(f"Failed to modify user with email: {user}")
 
 
-def check_invalid_env(env):
+def validate_env(env):
     """
-    Checks for an invalid enviroment. Currently, it will only check for api, eu, au, gov, or qa.
-    If you are using a standalone environment, then you MUST add it to this function
+    Validates environment. By default, it checks for api, eu, au, gov and qa.
+    If you are using a standalone environment, then you must add it to the environments list
     """
 
-    Enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]
+    enviroments = ["https://api.cloudcheckr.com", "https://eu.cloudcheckr.com", "https://au.cloudcheckr.com", "https://gov.cloudcheckr.com", "https://qa.cloudcheckr.com"]
 
-    if env not in Enviroments:
-        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the check_invalid_env function.")
+    if env not in enviroments:
+        log_information(f"The environment {env} is not valid. If this is a standalone environment, please add the url to the validate_env function.")
 
 
 def main():
@@ -71,7 +71,7 @@ def main():
         return
 
     env = "https://api.cloudcheckr.com"
-    check_invalid_env(env)
+    validate_env(env)
 
     users = get_users_v2(admin_api_key, env)
     for user in users:


### PR DESCRIPTION
Use case is to programmatically modify a specific set of users to a desired result. For example, modify all PartnerSysAdmin users to Administrators.