### PR TITLE
Feature: Find Unmapped Accounts Lambda function

### DIFF
--- a/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
+++ b/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
@@ -15,6 +15,10 @@
       "Type": "String",
       "Description": "Email address for receiving notifications"
     },
+    "KMSKey": {
+      "Type" "String",
+      "Description": "Arn of the KMS key used to encrypt the cc_admin_access_key secure string"
+    },
     "S3Bucket": {
       "Type": "String",
       "Description": "Name of the bucket where the zip file is"
@@ -130,9 +134,7 @@
                   "Action": [
                     "kms:Decrypt"
                   ],
-                  "Resource": [
-                    "Ref": "KMSKey"
-                  ]
+                  "Resource": { "Ref": "KMSKey" }
                 },
                 {
                   "Sid": "ParameterStore",

--- a/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
+++ b/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
@@ -57,7 +57,7 @@
       "Type": "AWS::Events::Rule",
       "Properties": {
         "Description": "Triggers the find-unmapped-accounts function",
-        "Name": "Find-Unmapped-Accounts-Cron-Job"
+        "Name": "Find-Unmapped-Accounts-Cron-Job",
         "ScheduleExpression": {
           "Ref": "CronExpression"
         },

--- a/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
+++ b/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
@@ -16,7 +16,7 @@
       "Description": "Email address for receiving notifications"
     },
     "KMSKey": {
-      "Type" "String",
+      "Type": "String",
       "Description": "Arn of the KMS key used to encrypt the cc_admin_access_key secure string"
     },
     "S3Bucket": {

--- a/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
+++ b/Cost/FindUnmappedAccounts/FindUnmappedAccounts.json
@@ -1,0 +1,181 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Find Unmapped Accounts in CloudCheckr function",
+  "Parameters": {
+    "CronExpression": {
+      "Type": "String",
+      "Description": "Cron expression for triggering the function",
+      "Default": "cron(0 13-23 ? * MON-FRI *)"
+    },
+    "SourceEmailAddress": {
+      "Type": "String",
+      "Description": "Email address for sending notifications"
+    },
+    "DestEmailAddress": {
+      "Type": "String",
+      "Description": "Email address for receiving notifications"
+    },
+    "S3Bucket": {
+      "Type": "String",
+      "Description": "Name of the bucket where the zip file is"
+    },
+    "S3Key": {
+      "Type": "String",
+      "Description": "Path to the zip file within the bucket"
+    }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Deployment Parameters"
+          },
+          "Parameters": [
+            "S3Bucket",
+            "S3Key"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Notification Parameters"
+          },
+          "Parameters": [
+            "SourceEmailAddress",
+            "DestEmailAddress"
+          ]
+        },
+      ]
+    }
+  },
+  "Resources": {
+    "CWCronJob": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "Description": "Triggers the find-unmapped-accounts function",
+        "Name": "Find-Unmapped-Accounts-Cron-Job"
+        "ScheduleExpression": {
+          "Ref": "CronExpression"
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "FindUnmappedAccountsFunction",
+                "Arn"
+              ]
+            },
+            "Id": "FindUnmappedAccounts",
+            "Input": {
+              "Fn::Join": [
+                "",
+                [
+                  "{",
+                  "\"notificationsBool\": \"true\"",
+                  "}"
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "FindUnmappedAccountsRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        },
+        "RoleName": "lambda_find_unmapped_accounts",
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "lambda-find-unmapped-accounts-policy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Resource": "arn:aws:logs:*:*:*"
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ses:SendEmail"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Sid": "KMSDecrypt",
+                  "Effect": "Allow",
+                  "Action": [
+                    "kms:Decrypt"
+                  ],
+                  "Resource": [
+                    "Ref": "KMSKey"
+                  ]
+                },
+                {
+                  "Sid": "ParameterStore",
+                  "Effect": "Allow",
+                  "Action": "ssm:GetParameters",
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "FindUnmappedAccountsFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "FunctionName": "find_unmapped_accounts",
+        "Description" : "Detects payee accounts not part of a CloudCheckr account family and alerts via SES",
+        "Handler": "find_unmapped_accounts.handler",
+        "Runtime": "nodejs4.3",
+        "Timeout": 60,
+        "Role": {
+          "Fn::GetAtt": [
+            "FindUnmappedAccountsRole",
+            "Arn"
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "sourceAddr": { "Ref": "SourceEmailAddress" },
+            "destAddr": { "Ref": "DestEmailAddress" }
+          }
+        },
+        "Code": {
+          "S3Bucket": {
+            "Ref": "S3Bucket"
+          },
+          "S3Key": {
+            "Ref": "S3Key"
+          }
+        }
+      }
+    }
+  },
+  "Outputs": {}
+}

--- a/Cost/FindUnmappedAccounts/README.md
+++ b/Cost/FindUnmappedAccounts/README.md
@@ -1,6 +1,6 @@
 # Find Unmapped Accounts
 
-Searches CloudCheckr account for any accounts which are not mapped to an account family. If it finds any, it notifies an SNS topic. T
+Searches CloudCheckr account for any accounts which are not mapped to an account family. If it finds any, it notifies an SNS topic. The script runs during business hours by default, but this behavior can be modified by cron expression.
 
 ## Prerequisites
 

--- a/Cost/FindUnmappedAccounts/README.md
+++ b/Cost/FindUnmappedAccounts/README.md
@@ -1,12 +1,16 @@
 # Find Unmapped Accounts
 
-Searches CloudCheckr account for any accounts which are not mapped to an account family. If it finds any, it notifies an SNS topic. The script runs during business hours by default, but this behavior can be modified by cron expression.
+Searches CloudCheckr account for any accounts which are not mapped to an account family. If it finds any, it notifies an email address via SES. SES was chosen over SNS for its ability to render HTML messages.
+
+The script runs during business hours by default, but this behavior can be modified by cron expression.
 
 ## Prerequisites
 
 1. At least one AWS payer account configured as a CloudCheckr project
 2. A CloudCheckr [admin API key](https://success.cloudcheckr.com/article/gbnfxmoyo6-)
-3. A Systems Manager parameter named `html_encoded_semicolon_separated_master_payers` with the value(s) of the project names for AWS payer accounts in CloudCheckr, [html encoded](https://codebeautify.org/html-encode-string) and delimited by `;`
+  * Encrypt this key as a secure string named `cc_admin_access_key` in Systems Manager parameter store and note the KMS key used for the encryption
+3. A Systems Manager parameter (normal string) named `html_encoded_semicolon_separated_master_payers` with the value(s) of the project names for AWS payer accounts in CloudCheckr, [html encoded](https://codebeautify.org/html-encode-string) and delimited by `;`
+4. A verified email address in SES for the `From` field, and either a verified email or [production mode](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) active in the account
 
 ## Launch Instructions
 
@@ -16,7 +20,4 @@ Searches CloudCheckr account for any accounts which are not mapped to an account
   * In the the cloned directory, run `npm install` (with no options). This will create a directory called node_modules and will install dependencies based on package.json
   * Zip the node_modules folder and the validate_cc_acct_fams.js file together
 2. Upload the zip to S3
-3. Create a CloudFormation stack from [ValidateAccountFamilies_CF.json](ValidateAccountFamilies_CF.json) with the appropriate parameters
-  * If you already have an SNS topic created, input the name and choose `false` for `CreateSnsTopic`. In this case the `PrimaryNotificationEmail` won't matter, so you can leave it blank
-  * If you would like CloudFormation to create an SNS topic for you, input a name (must be unique within your account), and choose `CreateSnsTopic` `true`. Optonally enter a `PrimaryNotificationEmail`
-4. You're ready to go! Confirm the SNS subscription if applicable and the CloudWatch rule + AWS Lambda will do the rest!
+3. Create a CloudFormation stack from [FindUnmappedAccounts.json](FindUnmappedAccounts.json) with the appropriate parameters

--- a/Cost/FindUnmappedAccounts/README.md
+++ b/Cost/FindUnmappedAccounts/README.md
@@ -1,0 +1,22 @@
+# Find Unmapped Accounts
+
+Searches CloudCheckr account for any accounts which are not mapped to an account family. If it finds any, it notifies an SNS topic. T
+
+## Prerequisites
+
+1. At least one AWS payer account configured as a CloudCheckr project
+2. A CloudCheckr [admin API key](https://success.cloudcheckr.com/article/gbnfxmoyo6-)
+3. A Systems Manager parameter named `html_encoded_semicolon_separated_master_payers` with the value(s) of the project names for AWS payer accounts in CloudCheckr, [html encoded](https://codebeautify.org/html-encode-string) and delimited by `;`
+
+## Launch Instructions
+
+1. Create a deployment package for the Lambda function
+  * Clone to your local desktop
+  * [Install NodeJS](https://nodejs.org/en/download/) if not already on your machine
+  * In the the cloned directory, run `npm install` (with no options). This will create a directory called node_modules and will install dependencies based on package.json
+  * Zip the node_modules folder and the validate_cc_acct_fams.js file together
+2. Upload the zip to S3
+3. Create a CloudFormation stack from [ValidateAccountFamilies_CF.json](ValidateAccountFamilies_CF.json) with the appropriate parameters
+  * If you already have an SNS topic created, input the name and choose `false` for `CreateSnsTopic`. In this case the `PrimaryNotificationEmail` won't matter, so you can leave it blank
+  * If you would like CloudFormation to create an SNS topic for you, input a name (must be unique within your account), and choose `CreateSnsTopic` `true`. Optonally enter a `PrimaryNotificationEmail`
+4. You're ready to go! Confirm the SNS subscription if applicable and the CloudWatch rule + AWS Lambda will do the rest!

--- a/Cost/FindUnmappedAccounts/README.md
+++ b/Cost/FindUnmappedAccounts/README.md
@@ -10,7 +10,7 @@ The script runs during business hours by default, but this behavior can be modif
 2. A CloudCheckr [admin API key](https://success.cloudcheckr.com/article/gbnfxmoyo6-)
   * Encrypt this key as a secure string named `cc_admin_access_key` in Systems Manager parameter store and note the KMS key used for the encryption
 3. A Systems Manager parameter (normal string) named `html_encoded_semicolon_separated_master_payers` with the value(s) of the project names for AWS payer accounts in CloudCheckr, [html encoded](https://codebeautify.org/html-encode-string) and delimited by `;`
-4. A verified email address in SES for the `From` field, and either a verified email or [production mode](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) active in the account
+4. A verified email address in SES for source email address, and either a verified email or [production mode](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/request-production-access.html) active in the account for sending to the destination address
 
 ## Launch Instructions
 

--- a/Cost/FindUnmappedAccounts/find_unmapped_accounts.js
+++ b/Cost/FindUnmappedAccounts/find_unmapped_accounts.js
@@ -73,7 +73,7 @@ function processEvent(event, context, callback) {
                             BccAddresses: [], 
                             CcAddresses: [], 
                             ToAddresses: [
-                                "something"
+                                process.env.destAddr
                             ]
                         }, 
                         Message: {
@@ -96,7 +96,7 @@ function processEvent(event, context, callback) {
                                 Data: "Unmapped CloudCheckr Accounts Found"
                             }
                         },
-                        Source: "awsresell@jhctechnology.com"
+                        Source: process.env.sourceAddr
                     };
                     ses.sendEmail(params, function(err, data) {
                         if (err) console.log(err, err.stack); // an error occurred

--- a/Cost/FindUnmappedAccounts/find_unmapped_accounts.js
+++ b/Cost/FindUnmappedAccounts/find_unmapped_accounts.js
@@ -1,0 +1,136 @@
+const request = require('sync-request');
+const AWSXRay = require('aws-xray-sdk-core');
+const AWS = AWSXRay.captureAWS(require('aws-sdk'));
+AWS.config.update({region: process.env.AWS_REGION});
+var ssm = new AWS.SSM();
+
+const api_base = "https://api2.cloudcheckr.com/";
+var cc_admin_access_key = '';
+
+function processEvent(event, context, callback) {
+    
+    var masterPayerArr;
+    try {
+        var params = {
+            Names: [
+                'html_encoded_semicolon_separated_master_payers'
+            ]
+        };
+        
+        ssm.getParameters(params, function(err, data) {
+            if (err) {
+                console.log(err, err.stack); // an error occurred
+                callback(err);
+            } else if (data['Parameters'] == undefined) {
+                callback("SSM was able to reach parameter store, but no parameter was found for the payer accounts.");
+            } else {
+                masterPayerArr = data['Parameters'][0]['Value'].split(',');
+
+                var account_list;
+                console.log(masterPayerArr);
+                
+                for (var masterPayerNum in masterPayerArr) {
+                    var masterPayer = masterPayerArr[masterPayerNum];
+
+                    var options = {
+                        host: api_base,
+                        path: 'api/billing.json/get_account_family?access_key=' + cc_admin_access_key + '&use_account=' + masterPayer
+                    };
+
+                    console.log('Getting the list of account families for ' + masterPayer + '...');
+                    var response = request('GET', options['host'] + options['path']);
+                    var response_array;
+
+                    if (response.statusCode == 200) {
+                        //console.log(response.body); // Show the response
+                        response_array = JSON.parse(response.body);
+                        //console.log(response_array);
+                        if (response_array['UnmappedAccounts'].length === 0) {
+                            console.log('No unmapped accounts found in ' + masterPayer + '.');
+                            //callback(null, false); /* Indicates success with information returned to the caller. */
+                        } else {
+                            console.log('Unmapped accounts found in ' + masterPayer + '.');
+                            
+                            response_array['UnmappedAccounts'].forEach(function(entry) {
+                                if (account_list == undefined) {
+                                    account_list = entry;
+                                } else {
+                                    account_list += '\n' + entry;
+                                }
+                            });
+                        }
+                    } else {
+                        console.log('Error: ' + response.statusCode + ' ' + response.body + '. Exiting...');
+                        context.fail('Could not retrieve data from CloudCheckr');
+                    }
+                }
+                            
+                if (account_list != undefined && (event.notificationsBool === "true" || event.notificationsBool == undefined)) {
+                    var ses = new AWS.SES();
+                    
+                    var params = {
+                        Destination: {
+                            BccAddresses: [], 
+                            CcAddresses: [], 
+                            ToAddresses: [
+                                "something"
+                            ]
+                        }, 
+                        Message: {
+                            Body: {
+                                Html: {
+                                    Charset: "UTF-8", 
+                                    Data: "Hello,<p>Some accounts were found in CloudCheckr which are not mapped to an Account Family. " 
+                                    + "Mapping accounts to an account family is necessary for invoicing. These are the unmapped accounts:</p>"
+                                    + "<p>" + account_list.replace(/\n/i, '<br />') + "</p>"
+                                }, 
+                                Text: {
+                                    Charset: "UTF-8", 
+                                    Data: "Hello,\n\nSome accounts were found in CloudCheckr which are not mapped to an Account Family. " 
+                                    + "Mapping accounts to an account family is necessary for invoicing. These are the unmapped accounts:"
+                                    + "\n\n" + account_list
+                                }
+                            }, 
+                            Subject: {
+                                Charset: "UTF-8", 
+                                Data: "Unmapped CloudCheckr Accounts Found"
+                            }
+                        },
+                        Source: "awsresell@jhctechnology.com"
+                    };
+                    ses.sendEmail(params, function(err, data) {
+                        if (err) console.log(err, err.stack); // an error occurred
+                        else     console.log(data);           // successful response
+                    });
+                }
+            }
+        });  
+    } catch (e) {
+        console.log(e);
+        callback(1);
+    }
+}
+
+exports.handler = (event, context, callback) => {
+    "use strict";
+
+    var params = {
+        Names: [
+            'cc_admin_access_key'
+        ],
+        WithDecryption: true
+    };
+
+    ssm.getParameters(params, function(err, data) {
+        if (err) {
+            console.log(err, err.stack); // an error occurred
+            callback(err);
+        } else if (data['Parameters'] == undefined) {
+            console.log(data);
+            callback("SSM was able to reach parameter store, but no parameter was found for the access key.");
+        } else {
+            cc_admin_access_key = data['Parameters'][0]['Value'];
+            processEvent(event, context, callback);
+        }
+    });
+};

--- a/Cost/FindUnmappedAccounts/package.json
+++ b/Cost/FindUnmappedAccounts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "find_unmapped_accounts",
+  "version": "1.0.0",
+  "description": "validate account families in CloudCheckr",
+  "main": "find_unmapped_accounts.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Michael Atkinson",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "aws-sdk": "^2.6.1",
+    "request": "^2.74.0"
+  },
+  "devDependencies": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CloudCheckr/Developer-Community.git"
+  },
+  "keywords": [
+    "cloudcheckr",
+    "account",
+    "families"
+  ],
+  "bugs": {
+    "url": "https://github.com/CloudCheckr/Developer-Community/issues"
+  },
+  "homepage": "https://github.com/CloudCheckr/Developer-Community/tree/master/Cost/FindUnmappedAccounts#readme"
+}


### PR DESCRIPTION
This Lambda script and CloudFormation template create a scheduled job which scans the CloudCheckr account for AWS accounts which are not mapped to an account family and notifies an email address via SES. The function helps to ensure early notification of any unmapped accounts as mapping accounts to an account family may be a prerequisite to performing invoicing, generating reports, receiving accurate alerts, or making cost data available to an L2 partner account.