### PR TITLE
Cloud formation template

### DIFF
--- a/CloudFormationTemplate/CF_Template_README.txt
+++ b/CloudFormationTemplate/CF_Template_README.txt
@@ -1,0 +1,27 @@
+A cross-account role allows you to share resources across AWS accounts. Since your cross-account role works globally, you don't need IAM users to sign in and out of accounts to access these resources.
+
+The CloudFormation template is an alternative to creating a cross-account role manually. It is a JSON file pre-configured with all the parameters and provisions you need to access your AWS resources across multiple accounts in your cloud environment. This template allows AWS to standardize permissions across your deployment automatically.
+
+To view a detailed list of instructions, please go to https://success.cloudcheckr.com/article/3ldmqs5pzn-creating-aws-credentials-with-cloud-formation for more details.
+
+Please note, our CloudFormation template is only intended to credential Commercial AWS Accounts.  For GovCloud accounts, IAM Access Keys will be required, more details can be found at https://success.cloudcheckr.com/article/99vns4x2ho-configure-gov-cloud-account-iam-access-keys.
+
+#######################
+Policy Structure Notes:
+#######################
+
+Unauthorized Access:
+CloudCheckr will attempt to ingest data from all of the AWS core features to populate the Cost, Billing, Security, Inventory, and CloudWatch Flow Log reports. Since CloudCheckr must make calls even to those categories where you have not enabled permissions, you will see "Unauthorized Access" attempts in your CloudTrail logs. These logs are only an indication of the CloudCheckr workflow and in no way reflect an attempt on the part of CloudCheckr to collect unauthorized information from customers.
+
+s3:GetObject
+To help you maintain a secure, least privilege configuration, CloudCheckr's Security/Compliance policy does not include any "s3:GetObject" permissions. However, you can add add the "s3:GetObject" permission to the following reports:
+
+- S3 Encryption Details report: enables CloudCheckr scan your encrypted S3 buckets.
+      --> We recommend restricting this permission to only selected S3 bucket(s).
+
+- List of VPCs report: enables CloudCheckr to ingest data from the Elastic Beanstalk applications for this report.
+      --> The default Security/Compliance policy will only display 0 as the number of Elastic Beanstalk applications within a VPC.
+
+s3:GetEncryptionConfigruation:
+As per the latest AWS requirements, CloudCheckr's CloudFormation template and the Inventory policy do not include the "s3:GetEncryptionConfiguration" by default.
+However, without this permission, CloudCheckr cannot get the information it needs to report on the "S3 Bucket Without Default Encryption Enabled" Best Practice Check (BPC). If you decide not to add this permission to your policy, we recommend that you ignore or disable this BPC to avoid any false negatives.

--- a/CloudFormationTemplate/Commercial_CloudFormation_Template.json
+++ b/CloudFormationTemplate/Commercial_CloudFormation_Template.json
@@ -1,0 +1,503 @@
+{
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Metadata":{
+		"AWS::CloudFormation::Interface":{
+			"ParameterGroups":[
+				{
+					"Label":{"default":"IAM Role"},
+					"Parameters":["ExternalAccount","ExternalId", "AccountType"]
+				},
+				{
+					"Label":{"default":"Inventory"},
+					"Parameters":["InventoryAndUtilzation"]
+				},
+				{
+					"Label":{"default":"Billing"},
+					"Parameters":["CostPermissions","BillingBucket", "CurBucket"]
+				},
+				{
+					"Label":{"default":"Security"},
+					"Parameters":["Security","CloudTrailBucket"]
+				},
+				{
+					"Label":{"default":"CloudWatch Flow Logs"},
+					"Parameters":["CloudWatchFlowLogs"]
+				}
+			]
+		}
+	},
+	"Parameters": {
+		"ExternalId":{
+			"Type":"String",
+			"Description":"CloudCheckr External ID"
+		},
+		"ExternalAccount":{
+			"Type":"String",
+			"Default":"352813966189",
+			"Description":"CloudCheckr Account"
+		},
+		"AccountType":{
+			"Type":"String",
+			"Default":"Standard",
+			"Description":"Account Type",
+			"AllowedValues": ["Standard", "GovCloud"]
+		},
+		"Security":{
+			"Type": "String",
+			"Default": "True",
+			"Description": "Use CloudCheckr to process security data?",
+			"AllowedValues": ["True", "False"]
+		},
+		"InventoryAndUtilzation":{
+			"Type": "String",
+			"Default": "True",
+			"Description": "Use CloudCheckr to process inventory and utilization data?",
+			"AllowedValues": ["True", "False"]
+		},
+		"CostPermissions": {
+			"Type": "String",
+			"Default": "True",
+			"Description": "Use CloudCheckr to process billing data?",
+			"AllowedValues": ["True", "False"]
+		},
+		"BillingBucket":{
+			"Type":"String",
+			"Description":"AWS Detailed Billing Report Bucket"
+		},
+		"CurBucket":{
+			"Type":"String",
+			"Description":"AWS Cost and Usage Report Bucket"
+		},
+		"CloudTrailBucket":{
+			"Type":"String",
+			"Description":"AWS CloudTrail Bucket"
+		},
+		"CloudWatchFlowLogs":{
+			"Type": "String",
+			"Default": "True",
+			"Description": "Use CloudCheckr to process CloudWatch Flow Logs data?",
+			"AllowedValues": ["True", "False"]
+		}
+	},
+	"Conditions": {
+		"IncludeCost": {"Fn::Equals": [{"Ref": "CostPermissions"}, "True"]},
+		"IncludeInventory": {"Fn::Equals": [{"Ref": "InventoryAndUtilzation"}, "True"]},
+		"IncludeSecurity": {"Fn::Equals": [{"Ref": "Security"}, "True"]},
+		"IncludeFlowLogs": {"Fn::Equals": [{"Ref": "CloudWatchFlowLogs"}, "True"]},
+		"IncludeCloudTrailBucket": {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "CloudTrailBucket"}]}]},
+		"IsAccountTypeStandard": {"Fn::Equals": [{"Ref": "AccountType"}, "Standard"]},
+		"IncludeBillingBucket": { "Fn::And": [ {"Condition": "IsAccountTypeStandard"}, {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "BillingBucket"}]}]}]},
+		"IncludeCurBucket": { "Fn::And": [ {"Condition": "IsAccountTypeStandard"}, {"Fn::Not": [{"Fn::Equals": ["", {"Ref": "CurBucket"}]}]}]}
+	},
+	"Resources": {
+		"IamRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"AssumeRolePolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [{
+						"Effect": "Allow",
+						"Principal": {"AWS": { "Fn::If": [ "IsAccountTypeStandard", { "Fn::Sub": "arn:aws:iam::${ExternalAccount}:root"},{ "Fn::Sub": "arn:aws-us-gov:iam::${ExternalAccount}:root"}]}},
+						"Action": "sts:AssumeRole",
+						"Condition": {
+							"StringEquals": {
+								"sts:ExternalId": {
+									"Ref": "ExternalId"
+								}
+							}
+						}
+					}]
+				}
+			}
+		},
+		"CloudWatchFlowLogsPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeFlowLogs",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-CloudWatchFlowLogs-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[{
+						"Sid":"CloudWatchLogsSpecific",
+						"Effect":"Allow",
+						"Action":[
+							"logs:GetLogEvents",
+							"logs:DescribeLogGroups",
+							"logs:DescribeLogStreams"
+						],
+						"Resource":[
+							{ "Fn::If": [ "IsAccountTypeStandard", "arn:aws:logs:*:*:*", "arn:aws-us-gov:logs:*:*:*"]}
+						]
+					}]
+				}
+			}
+		},
+		"CloudTrailPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeCloudTrailBucket",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-CloudTrail-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[{
+						"Sid": "CloudTrailPermissions",
+						"Effect": "Allow",
+						"Action": [
+							"s3:GetBucketACL",
+							"s3:GetBucketLocation",
+							"s3:GetBucketLogging",
+							"s3:GetBucketPolicy",
+							"s3:GetBucketTagging",
+							"s3:GetBucketWebsite",
+							"s3:GetBucketNotification",
+							"s3:GetLifecycleConfiguration",
+							"s3:GetObject",
+							"s3:List*"
+						],
+						"Resource": [
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CloudTrailBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CloudTrailBucket}"}]},
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CloudTrailBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CloudTrailBucket}/*"}]}
+						]
+					}]
+				}
+			}
+		},
+		"SecurityPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeSecurity",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-Security-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[{
+						"Sid": "SecurityPermissons",
+						"Effect":"Allow",
+						"Action":[
+								"acm:DescribeCertificate",
+								"acm:ListCertificates",
+								"acm:GetCertificate",
+								"cloudtrail:DescribeTrails",
+								"cloudtrail:GetTrailStatus",
+								"logs:GetLogEvents",
+								"logs:DescribeLogGroups",
+								"logs:DescribeLogStreams",
+								"config:DescribeConfigRules",
+								"config:GetComplianceDetailsByConfigRule",
+								"config:DescribeDeliveryChannels",
+								"config:DescribeDeliveryChannelStatus",
+								"config:DescribeConfigurationRecorders",
+								"config:DescribeConfigurationRecorderStatus",
+								"ec2:Describe*",
+								"iam:Get*",
+								"iam:List*",
+								"iam:GenerateCredentialReport",
+								"kms:DescribeKey",
+								"kms:GetKeyPolicy",
+								"kms:GetKeyRotationStatus",
+								"kms:ListAliases",
+								"kms:ListGrants",
+								"kms:ListKeys",
+								"kms:ListKeyPolicies",
+								"kms:ListResourceTags",
+								"rds:Describe*",
+								"ses:ListIdentities",
+								"ses:GetSendStatistics",
+								"ses:GetIdentityDkimAttributes",
+								"ses:GetIdentityVerificationAttributes",
+								"ses:GetSendQuota",
+								"sns:GetTopicAttributes",
+								"sns:GetSubscriptionAttributes",
+								"sns:ListTopics",
+								"sns:ListSubscriptionsByTopic",
+								"sqs:ListQueues",
+								"sqs:GetQueueAttributes"
+							],
+						"Resource": "*"
+					}]
+				}
+			}
+		},
+		"InventoryPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeInventory",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-Inventory-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[{
+						"Sid":"InventoryAndUtilization",
+						"Effect":"Allow",
+						"Action":[
+							"acm:DescribeCertificate",
+							"acm:ListCertificates",
+							"acm:GetCertificate",
+							"ec2:Describe*",
+							"ec2:GetConsoleOutput",
+							"autoscaling:Describe*",
+							"cloudformation:DescribeStacks",
+							"cloudformation:GetStackPolicy",
+							"cloudformation:GetTemplate",
+							"cloudformation:ListStackResources",
+							"cloudfront:List*",
+							"cloudfront:GetDistributionConfig",
+							"cloudfront:GetStreamingDistributionConfig",
+							"cloudhsm:Describe*",
+							"cloudhsm:List*",
+							"cloudsearch:Describe*",
+							"cloudtrail:DescribeTrails",
+							"cloudtrail:GetTrailStatus",
+							"cloudwatch:DescribeAlarms",
+							"cloudwatch:GetMetricStatistics",
+							"cloudwatch:ListMetrics",
+							"cognito-identity:ListIdentities",
+							"cognito-identity:ListIdentityPools",
+							"cognito-idp:ListGroups",
+							"cognito-idp:ListIdentityProviders",
+							"cognito-idp:ListUserPools",
+							"cognito-idp:ListUsers",
+							"cognito-idp:ListUsersInGroup",
+							"config:DescribeConfigRules",
+							"config:GetComplianceDetailsByConfigRule",
+							"config:Describe*",
+							"datapipeline:ListPipelines",
+							"datapipeline:GetPipelineDefinition",
+							"datapipeline:DescribePipelines",
+							"directconnect:DescribeLocations",
+							"directconnect:DescribeConnections",
+							"directconnect:DescribeVirtualInterfaces",
+							"dynamodb:ListTables",
+							"dynamodb:DescribeTable",
+							"dynamodb:ListTagsOfResource",
+							"ecs:ListClusters",
+							"ecs:DescribeClusters",
+							"ecs:ListContainerInstances",
+							"ecs:DescribeContainerInstances",
+							"ecs:ListServices",
+							"ecs:DescribeServices",
+							"ecs:ListTaskDefinitions",
+							"ecs:DescribeTaskDefinition",
+							"ecs:ListTasks",
+							"ecs:DescribeTasks",
+							"ssm:ListResourceDataSync",
+							"ssm:ListAssociations",
+							"ssm:ListDocumentVersions",
+							"ssm:ListDocuments",
+							"ssm:ListInstanceAssociations",
+							"ssm:ListInventoryEntries",
+							"elasticache:Describe*",
+							"elasticache:List*",
+							"elasticbeanstalk:Describe*",
+							"elasticfilesystem:DescribeFileSystems",
+							"elasticfilesystem:DescribeTags",
+							"elasticloadbalancing:Describe*",
+							"elasticmapreduce:Describe*",
+							"elasticmapreduce:List*",
+							"es:ListDomainNames",
+							"es:DescribeElasticsearchDomains",
+							"glacier:ListTagsForVault",
+							"glacier:DescribeVault",
+							"glacier:GetVaultNotifications",
+							"glacier:DescribeJob",
+							"glacier:GetJobOutput",
+							"glacier:ListJobs",
+							"glacier:ListVaults",
+							"iam:Get*",
+							"iam:List*",
+							"iam:GenerateCredentialReport",
+							"iot:DescribeThing",
+							"iot:ListThings",
+							"kms:DescribeKey",
+							"kms:GetKeyPolicy",
+							"kms:GetKeyRotationStatus",
+							"kms:ListAliases",
+							"kms:ListGrants",
+							"kms:ListKeys",
+							"kms:ListKeyPolicies",
+							"kms:ListResourceTags",
+							"kinesis:ListStreams",
+							"kinesis:DescribeStream",
+							"kinesis:GetShardIterator",
+							"lambda:ListFunctions",
+							"lambda:ListTags",
+							"Organizations:List*",
+							"Organizations:Describe*",
+							"rds:Describe*",
+							"rds:List*",
+							"redshift:Describe*",
+							"route53:ListHealthChecks",
+							"route53:ListHostedZones",
+							"route53:ListResourceRecordSets",
+							"s3:GetBucketACL",
+							"s3:GetBucketLocation",
+							"s3:GetBucketLogging",
+							"s3:GetBucketPolicy",
+							"s3:GetBucketTagging",
+							"s3:GetBucketWebsite",
+							"s3:GetBucketNotification",
+							"s3:GetLifecycleConfiguration",
+							"s3:List*",
+							"sdb:ListDomains",
+							"sdb:DomainMetadata",
+							"ses:ListIdentities",
+							"ses:GetSendStatistics",
+							"ses:GetIdentityDkimAttributes",
+							"ses:GetIdentityVerificationAttributes",
+							"ses:GetSendQuota",
+							"sns:GetTopicAttributes",
+							"sns:GetSubscriptionAttributes",
+							"sns:ListTopics",
+							"sns:ListSubscriptionsByTopic",
+							"sqs:ListQueues",
+							"sqs:GetQueueAttributes",
+							"storagegateway:Describe*",
+							"storagegateway:List*",
+							"support:*",
+							"swf:ListClosedWorkflowExecutions",
+							"swf:ListDomains",
+							"swf:ListActivityTypes",
+							"swf:ListWorkflowTypes",
+							"workspaces:DescribeWorkspaceDirectories",
+							"workspaces:DescribeWorkspaceBundles",
+							"workspaces:DescribeWorkspaces"
+						],
+						"Resource":"*"
+					}]
+				}
+			}
+		},
+		"DbrPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeBillingBucket",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-DBR-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[{
+						"Sid":"CostReadDBR",
+						"Effect":"Allow",
+						"Action":[
+							"s3:GetBucketACL",
+							"s3:GetBucketLocation",
+							"s3:GetBucketLogging",
+							"s3:GetBucketPolicy",
+							"s3:GetBucketTagging",
+							"s3:GetBucketWebsite",
+							"s3:GetBucketNotification",
+							"s3:GetLifecycleConfiguration",
+							"s3:GetObject"
+						],
+						"Resource":[
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${BillingBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${BillingBucket}"}]},
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${BillingBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${BillingBucket}/*"}]}
+						]
+					}]
+				}
+			}
+		},
+		"CurPolicy":{
+			"Type":"AWS::IAM::Policy",
+			"Condition":"IncludeCurBucket",
+			"DependsOn":"IamRole",
+			"Properties":{
+				"Roles":[{"Ref":"IamRole"}],
+				"PolicyName":"CloudCheckr-CUR-Policy",
+				"PolicyDocument":{
+					"Version":"2012-10-17",
+					"Statement":[
+					{
+						"Sid":"CostReadCUR",
+						"Action":[
+							"s3:GetObject"
+						],
+						"Effect":"Allow",
+						"Resource":[
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CurBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CurBucket}"}]},
+							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CurBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CurBucket}/*"}]}
+						]
+					}]
+				}
+			}
+		},
+		"CostPolicy": {
+			"Type": "AWS::IAM::Policy",
+			"Condition": "IncludeCost",
+			"DependsOn":"IamRole",
+			"Properties": {
+				"PolicyName": "CloudCheckr-Cost-Policy",
+				"PolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [{
+							"Sid": "CloudCheckrCostPermissions",
+							"Action": [
+								"ce:GetReservationUtilization",
+								"ec2:DescribeAccountAttributes",
+								"ec2:DescribeAvailabilityZones",
+								"ec2:DescribeReservedInstancesOfferings",
+								"ec2:DescribeReservedInstances",
+								"ec2:DescribeReservedInstancesListings",
+								"ec2:DescribeHostReservationOfferings",
+								"ec2:DescribeReservedInstancesModifications",
+								"ec2:DescribeHostReservations",
+								"ec2:DescribeInstances",
+								"ec2:DescribeInstanceStatus",
+								"ec2:DescribeRegions",
+								"ec2:DescribeKeyPairs",
+								"ec2:DescribePlacementGroups",
+								"ec2:DescribeAddresses",
+								"ec2:DescribeSpotInstanceRequests",
+								"ec2:DescribeImages",
+								"ec2:DescribeImageAttribute",
+								"ec2:DescribeSnapshots",
+								"ec2:DescribeVolumes",
+								"ec2:DescribeTags",
+								"ec2:DescribeNetworkInterfaces",
+								"ec2:DescribeSecurityGroups",
+								"ec2:DescribeInstanceAttribute",
+								"ec2:DescribeVolumeStatus",
+								"elasticache:DescribeReservedCacheNodes",
+								"elasticache:DescribeReservedCacheNodesOfferings",
+								"rds:DescribeReservedDBInstances",
+								"rds:DescribeReservedDBInstancesOfferings",
+								"rds:DescribeDBInstances",
+								"redshift:DescribeReservedNodes",
+								"redshift:DescribeReservedNodeOfferings",
+								"s3:GetBucketACL",
+								"s3:GetBucketLocation",
+								"s3:GetBucketLogging",
+								"s3:GetBucketPolicy",
+								"s3:GetBucketTagging",
+								"s3:GetBucketWebsite",
+								"s3:GetBucketNotification",
+								"s3:GetLifecycleConfiguration",
+								"s3:List*",
+								"dynamodb:DescribeReservedCapacity",
+								"dynamodb:DescribeReservedCapacityOfferings",
+								"iam:GetAccountAuthorizationDetails",
+								"iam:ListRolePolicies",
+								"iam:ListAttachedRolePolicies"
+							],
+							"Effect": "Allow",
+							"Resource": "*"
+						}]
+					},
+					"Roles":[{"Ref":"IamRole"}]
+				}
+			}
+		},
+		"Outputs": {
+			"RoleArn":{
+				"Description":"ARN of the IAM Role",
+				"Value":{"Fn::GetAtt":["IamRole","Arn"]}
+			}
+		}
+	}


### PR DESCRIPTION
Added our commercial CF Template and README.txt to new folder: CloudFormationTemplate.  Waiting on Gettings to respond regarding GovCloud template. 

README.txt consists of our explanation of how CloudFormation can be used to provision a cross-account role taken from our success.cloudcheckr article noted in the txt file.  Policy Structure Notes are the 3 notifications at the bottom of the success document about additional permissions.