### PR TITLE
add role id to outputs

### DIFF
--- a/CloudFormationTemplate/Commercial_CloudFormation_Template.json
+++ b/CloudFormationTemplate/Commercial_CloudFormation_Template.json
@@ -498,6 +498,10 @@
 			"RoleArn":{
 				"Description":"ARN of the IAM Role",
 				"Value":{"Fn::GetAtt":["IamRole","Arn"]}
+			},
+			"RoleId": {
+				"Description":"Id of the IAM Role",
+				"Value":{"Fn::GetAtt":["IamRole","RoleId"]}
 			}
 		}
 	}


### PR DESCRIPTION
Role Ids are essential to configuring an S3 bucket for access from a single role only. This is key for organizations who want to add additional security to their S3 buckets containing billing data or CloudTrail logs. Manifesting this Id as an output in CloudFormation will open up automation capabilities for creating secure S3 buckets.