### PR TITLE
CloudFormation minor linting

### DIFF
--- a/CloudFormationTemplate/Commercial_CloudFormation_Template.json
+++ b/CloudFormationTemplate/Commercial_CloudFormation_Template.json
@@ -113,7 +113,6 @@
 		"CloudWatchFlowLogsPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeFlowLogs",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-CloudWatchFlowLogs-Policy",
@@ -137,7 +136,6 @@
 		"CloudTrailPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeCloudTrailBucket",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-CloudTrail-Policy",
@@ -169,7 +167,6 @@
 		"SecurityPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeSecurity",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-Security-Policy",
@@ -226,7 +223,6 @@
 		"InventoryPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeInventory",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-Inventory-Policy",
@@ -376,7 +372,6 @@
 		"DbrPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeBillingBucket",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-DBR-Policy",
@@ -407,7 +402,6 @@
 		"CurPolicy":{
 			"Type":"AWS::IAM::Policy",
 			"Condition":"IncludeCurBucket",
-			"DependsOn":"IamRole",
 			"Properties":{
 				"Roles":[{"Ref":"IamRole"}],
 				"PolicyName":"CloudCheckr-CUR-Policy",
@@ -431,7 +425,6 @@
 		"CostPolicy": {
 			"Type": "AWS::IAM::Policy",
 			"Condition": "IncludeCost",
-			"DependsOn":"IamRole",
 			"Properties": {
 				"PolicyName": "CloudCheckr-Cost-Policy",
 				"PolicyDocument": {

--- a/CloudFormationTemplate/Commercial_CloudFormation_Template.json
+++ b/CloudFormationTemplate/Commercial_CloudFormation_Template.json
@@ -97,7 +97,7 @@
 					"Version": "2012-10-17",
 					"Statement": [{
 						"Effect": "Allow",
-						"Principal": {"AWS": { "Fn::If": [ "IsAccountTypeStandard", { "Fn::Sub": "arn:aws:iam::${ExternalAccount}:root"},{ "Fn::Sub": "arn:aws-us-gov:iam::${ExternalAccount}:root"}]}},
+						"Principal": {"AWS": { "Fn::Sub": "arn:${AWS::Partition}:iam::${ExternalAccount}:root" } },
 						"Action": "sts:AssumeRole",
 						"Condition": {
 							"StringEquals": {
@@ -127,7 +127,7 @@
 							"logs:DescribeLogStreams"
 						],
 						"Resource":[
-							{ "Fn::If": [ "IsAccountTypeStandard", "arn:aws:logs:*:*:*", "arn:aws-us-gov:logs:*:*:*"]}
+							{ "Fn::Sub": "arn:${AWS::Partition}:logs:*:*:*" }
 						]
 					}]
 				}
@@ -157,8 +157,8 @@
 							"s3:List*"
 						],
 						"Resource": [
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CloudTrailBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CloudTrailBucket}"}]},
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CloudTrailBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CloudTrailBucket}/*"}]}
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${CloudTrailBucket}" },
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${CloudTrailBucket}/*" }
 						]
 					}]
 				}
@@ -392,8 +392,8 @@
 							"s3:GetObject"
 						],
 						"Resource":[
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${BillingBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${BillingBucket}"}]},
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${BillingBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${BillingBucket}/*"}]}
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${BillingBucket}" },
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${BillingBucket}/*" }
 						]
 					}]
 				}
@@ -415,8 +415,8 @@
 						],
 						"Effect":"Allow",
 						"Resource":[
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CurBucket}"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CurBucket}"}]},
-							{ "Fn::If": [ "IsAccountTypeStandard", {"Fn::Sub":"arn:aws:s3:::${CurBucket}/*"}, {"Fn::Sub":"arn:aws-us-gov:s3:::${CurBucket}/*"}]}
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${CurBucket}" },
+							{ "Fn::Sub":"arn:${AWS::Partition}:s3:::${CurBucket}/*" }
 						]
 					}]
 				}


### PR DESCRIPTION
Minor, non-functional changes to the CloudFormation template

* Remove `DependsOn` where the dependency is already implicit by a `Ref` or `GetAtt` (cfn-python-lint best practice)
* Use `AWS::Partition` pseudo-parameter for dynamically building standard and GovCloud ARNs dynamically