### PR TITLE
Add Control Tower CloudFormation Templates

### DIFF
--- a/aws-control-tower/README.md
+++ b/aws-control-tower/README.md
@@ -1,0 +1,29 @@
+# AWS Control Tower Integration
+
+
+## What is this?
+
+This is the folder that contains the CloudCheckr CMx AWS Control Tower Integration. AWS Control Tower is a Service that allows customers to more easily govern and secure a multi-account AWS environment. This CloudCheckr CMx AWS Control Tower integration allows customers to more easily add new AWS accounts to CloudCheckr.
+
+## Why are we doing this?
+
+The goal is to provide a way for CloudCheckr customers to use their existing AWS Control Tower set up to automatically add new accounts to CloudCheckr CMx. Any new account that gets added will recieve a daily assement of CloudCheckr's 500 best practice checks identifying ways to improve cost and security.
+
+## How do I use this?
+
+See our [implementation guide](https://d1.awsstatic.com/Marketplace/solutions-center/downloads/AWS-CloudCheckr-Implementation-Guide.pdf) for full details.
+
+
+## CloudFormation Templates
+
+Here are the two CloudFormation templates in the templates folder.
+
+* `cloudcheckr-controltower-integration.template.yaml` is the template to deploy the integration. It will require the s3 bucket and file with the lambda zip artifact.
+* `iam-permissions-control-tower-integration.json` is the template to create the cross-account IAM role. This template takes the IAM role name as an input.
+
+## Contributing
+
+This is an open source project and welcomes contributions.
+
+
+See our [Contributing Guide](../CONTRIBUTING.md) for more details.

--- a/aws-control-tower/templates/cloudcheckr-controltower-integration.template.yaml
+++ b/aws-control-tower/templates/cloudcheckr-controltower-integration.template.yaml
@@ -1,0 +1,266 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CloudCheckr ControlTower Integration.
+Parameters:
+  LambdaBucket:
+    Type: String
+    MinLength: '1'
+    AllowedPattern: '[a-zA-Z0-9-.]*'
+    Description: The prefix of the S3 bucket containing the Lambda package and templates.
+    Default: cc-public-resources
+  LambdaPath:
+    Type: String
+    MinLength: '1'
+    Description: The path to the lambda package file within the bucket.
+    Default: packages/cc_ct_integration_1.0.0.zip
+  StackSetName:
+    Type: String
+    MinLength: '1'
+    Description: Name for the StackSet to create stack instances in new accounts.
+    Default: 'CloudCheckr-ControlTower-StackSet'
+  StackSetTemplateUrl:
+    Type: String
+    MinLength: '1'
+    Description: S3 URL of the CloudFormation template for new accounts. Change the region name suffix on the URL to the Control Tower supported region you are deploying into.
+    Default: 'https://cc-public-resources-us-east-1.s3.amazonaws.com/templates/cc_aws_cfn_iam_stack.template.json'
+  ExternalAccount:
+    Type: String
+    MinLength: '12'
+    MaxLength: '12'
+    Description: CloudCheckr Account ID for cross-account trust.
+    Default: '352813966189'
+  SnsTopicName:
+    Type: String
+    MinLength: '3'
+    Description: SNS Topic to which the Lambda will push notifications in case of failure or important notifications.
+    Default: CloudCheckr-Control-Tower-Integration-Topic
+  ApiClientId:
+    Type: String
+    NoEcho: false
+    MinLength: '36'
+    MaxLength: '36'
+    Description: CloudCheckr API Client ID.
+  ApiClientSecret:
+    Type: String
+    NoEcho: true
+    MinLength: '32'
+    Description: CloudCheckr API Client Secret.
+  ApiClientEndpoint:
+    Type: String
+    Description: CloudCheckr API Endpoint to use.
+    Default: US
+    AllowedValues:
+      - US
+      - AU
+      - EU
+  ApiClientRegionGroup:
+    Type: String
+    Description: CloudCheckr API Region Group for Accounts Credentials Setup.
+    Default: Commercial
+    AllowedValues:
+      - Commercial
+Metadata:
+  'AWS::CloudFormation::Interface':
+    ParameterGroups:
+      - Label:
+          default: Integration Configuration
+        Parameters:
+          - ApiClientId
+          - ApiClientSecret
+          - ApiClientEndpoint
+          - ApiClientRegionGroup
+      - Label:
+          default: Cloud Formation and StackSets Information
+        Parameters:
+          - LambdaBucket
+          - LambdaPath
+          - SnsTopicName
+          - ExternalAccount
+          - StackSetName
+          - StackSetTemplateUrl
+Resources:
+  CreateAccountLifeCycleRule:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: Life Cycle for CreateManagedAccount
+      EventPattern:
+        source:
+          - aws.controltower
+        detail-type:
+          - AWS Service Event via CloudTrail
+        detail:
+          eventSource:
+            - controltower.amazonaws.com
+          eventName:
+            - CreateManagedAccount
+          userAgent:
+            - AWS Internal
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt 
+            - CloudCheckrLifeCycleLambda
+            - Arn
+          Id: CreateAccountLifeCycle
+  CreateAccountLifeCycleRulePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !Ref CloudCheckrLifeCycleLambda
+      Action: 'lambda:InvokeFunction'
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt 
+        - CreateAccountLifeCycleRule
+        - Arn
+  SnsTopic:
+    Type : AWS::SNS::Topic
+    Properties:
+        TopicName: !Ref SnsTopicName
+        DisplayName: !Ref SnsTopicName
+  Credentials:
+    Type: 'AWS::SecretsManager::Secret'
+    Properties:
+      Description: CloudCheckr API Credentials
+      Name: "CloudCheckrApiCredentialsSecret"
+      SecretString: !Join 
+        - ''
+        - - '{"ApiClientId":"'
+          - !Ref ApiClientId
+          - '","ApiClientSecret":"'
+          - !Ref ApiClientSecret
+          - '","ApiClientEndpoint":"'
+          - !Ref ApiClientEndpoint
+          - '","ApiClientRegionGroup":"'
+          - !Ref ApiClientRegionGroup
+          - '"}'
+      KmsKeyId: !GetAtt CloudCheckrControlTowerKMSKey.Arn
+    DependsOn:
+      - CloudCheckrControlTowerKMSKey
+  CloudCheckrLifeCycleLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      FunctionName: "CloudCheckr-ControlTower-Integration-LifeCycle"
+      Description: Function to handle Control Tower LifeCycle
+      Handler: >-
+        Lambda.ControlTowerIntegration::Lambda.ControlTowerIntegration.Function::FunctionHandler
+      Role: !GetAtt 
+        - CloudCheckrLifeCycleLambdaRole
+        - Arn
+      Code:
+        S3Bucket: !Join ['-', [!Ref LambdaBucket, !Ref 'AWS::Region']]
+        S3Key: !Ref LambdaPath
+      Runtime: dotnetcore2.1
+      MemorySize: 128
+      Timeout: 300
+      Environment:
+        Variables:
+          STACKSET_NAME: !Ref StackSetName
+          STACKSET_URL: !Ref StackSetTemplateUrl
+          EXTERNAL_ACCOUNT: !Ref ExternalAccount
+          SECRETS_ARN: !Ref Credentials
+          TOPIC_ARN: !Ref SnsTopic
+    DependsOn:
+      - Credentials
+      - SnsTopic
+  CloudCheckrControlTowerKMSKey:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: KMS Key used to encrypt/decrypt the CloudCheckr-ControlTower Integration Credentials
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: KMSAdminOperations
+          Effect: Allow
+          Principal:
+            AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+          Action:
+            - kms:*
+          Resource: '*'
+        - Sid: KMSOperations
+          Effect: Allow
+          Principal:
+            AWS: !Sub '${AWS::AccountId}'
+          Action:
+            - kms:Encrypt
+            - kms:Decrypt
+            - kms:ReEncrypt*
+            - kms:GenerateDataKey*
+            - kms:CreateGrant
+            - kms:DescribeKey
+          Resource: '*'
+          Condition:
+            StringEquals:
+              kms:ViaService: !Sub 'secretsmanager.${AWS::Region}.amazonaws.com'
+              kms:CallerAccount: !Sub '${AWS::AccountId}'
+  CloudCheckrControlTowerKMSAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: !Sub 'alias/${AWS::StackName}'
+      TargetKeyId:
+        Ref: CloudCheckrControlTowerKMSKey
+  CloudCheckrLifeCycleLambdaRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Description: Role used by Lambda for life cycle / new account creation
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: LambaPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: STSAssumeRole
+                Effect: Allow
+                Action:
+                  - sts:AssumeRole
+                Resource: 
+                  - 'arn:aws:iam::*:role/AWSControlTowerExecution'
+              - Sid: IAMOperations
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub 'arn:aws:iam::${AWS::AccountId}:role/service-role/AWSControlTowerStackSetRole'
+              - Sid: S3Operations
+                Effect: Allow
+                Action:
+                  - 's3:GetObject'
+                Resource: 
+                  - !Join ['',['arn:aws:s3:::', !Ref LambdaBucket ,'*']]
+              - Sid: SecretsManagerOperations
+                Effect: Allow
+                Action:
+                  - 'secretsmanager:GetSecretValue'
+                Resource:
+                  - !Ref Credentials
+              - Sid: CloudFormationOperations
+                Effect: Allow
+                Action:
+                  - 'cloudformation:CreateStackInstances'
+                  - 'cloudformation:DescribeStackInstance'
+                  - 'cloudformation:DescribeStackSetOperation'
+                  - 'cloudformation:CreateStackSet'
+                  - 'cloudformation:DescribeStackSet'
+                Resource:
+                  - !Join ['',['arn:aws:cloudformation:', !Ref 'AWS::Region', ':', !Ref 'AWS::AccountId', ':stackset/', !Ref StackSetName, ':*']]
+              - Sid: SnsOperations
+                Effect: Allow
+                Action: 
+                  - 'sns:Publish'
+                Resource:
+                  - !Ref SnsTopic
+              - Sid: KMSOperations
+                Effect: Allow
+                Action:
+                  - 'kms:GenerateDataKey'
+                  - 'kms:Decrypt'
+                Resource:
+                  - !GetAtt CloudCheckrControlTowerKMSKey.Arn

--- a/aws-control-tower/templates/iam-permissions-control-tower-integration.json
+++ b/aws-control-tower/templates/iam-permissions-control-tower-integration.json
@@ -1,0 +1,707 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "IAM Role"
+          },
+          "Parameters": [
+            "RoleName",
+            "ExternalAccount",
+            "ExternalId",
+            "AccountType"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Inventory"
+          },
+          "Parameters": [
+            "InventoryAndUtilzation"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Billing"
+          },
+          "Parameters": [
+            "CostPermissions",
+            "BillingBucket",
+            "CurBucket"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Security"
+          },
+          "Parameters": [
+            "Security",
+            "CloudTrailBucket"
+          ]
+        },
+        {
+          "Label": {
+            "default": "CloudWatch Flow Logs"
+          },
+          "Parameters": [
+            "CloudWatchFlowLogs"
+          ]
+        }
+      ]
+    }
+  },
+  "Parameters": {
+    "RoleName": {
+      "Type": "String",
+      "Default": "CloudCheckr-Role",
+      "Description": "Name for the IAM role to be created"
+    },
+    "ExternalId": {
+      "Type": "String",
+      "Description": "CloudCheckr External ID"
+    },
+    "ExternalAccount": {
+      "Type": "String",
+      "Default": "352813966189",
+      "Description": "CloudCheckr Account"
+    },
+    "AccountType": {
+      "Type": "String",
+      "Default": "Standard",
+      "Description": "Account Type",
+      "AllowedValues": [
+        "Standard",
+        "GovCloud"
+      ]
+    },
+    "Security": {
+      "Type": "String",
+      "Default": "True",
+      "Description": "Use CloudCheckr to process security data?",
+      "AllowedValues": [
+        "True",
+        "False"
+      ]
+    },
+    "InventoryAndUtilzation": {
+      "Type": "String",
+      "Default": "True",
+      "Description": "Use CloudCheckr to process inventory and utilization data?",
+      "AllowedValues": [
+        "True",
+        "False"
+      ]
+    },
+    "CostPermissions": {
+      "Type": "String",
+      "Default": "True",
+      "Description": "Use CloudCheckr to process billing data?",
+      "AllowedValues": [
+        "True",
+        "False"
+      ]
+    },
+    "BillingBucket": {
+      "Type": "String",
+      "Description": "AWS Detailed Billing Report Bucket"
+    },
+    "CurBucket": {
+      "Type": "String",
+      "Description": "AWS Cost and Usage Report Bucket"
+    },
+    "CloudTrailBucket": {
+      "Type": "String",
+      "Description": "AWS CloudTrail Bucket"
+    },
+    "CloudWatchFlowLogs": {
+      "Type": "String",
+      "Default": "True",
+      "Description": "Use CloudCheckr to process CloudWatch Flow Logs data?",
+      "AllowedValues": [
+        "True",
+        "False"
+      ]
+    }
+  },
+  "Conditions": {
+    "IncludeCost": {
+      "Fn::Equals": [
+        {
+          "Ref": "CostPermissions"
+        },
+        "True"
+      ]
+    },
+    "IncludeInventory": {
+      "Fn::Equals": [
+        {
+          "Ref": "InventoryAndUtilzation"
+        },
+        "True"
+      ]
+    },
+    "IncludeSecurity": {
+      "Fn::Equals": [
+        {
+          "Ref": "Security"
+        },
+        "True"
+      ]
+    },
+    "IncludeFlowLogs": {
+      "Fn::Equals": [
+        {
+          "Ref": "CloudWatchFlowLogs"
+        },
+        "True"
+      ]
+    },
+    "IncludeCloudTrailBucket": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            "",
+            {
+              "Ref": "CloudTrailBucket"
+            }
+          ]
+        }
+      ]
+    },
+    "IsAccountTypeStandard": {
+      "Fn::Equals": [
+        {
+          "Ref": "AccountType"
+        },
+        "Standard"
+      ]
+    },
+    "IncludeBillingBucket": {
+      "Fn::And": [
+        {
+          "Condition": "IsAccountTypeStandard"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                "",
+                {
+                  "Ref": "BillingBucket"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "IncludeCurBucket": {
+      "Fn::And": [
+        {
+          "Condition": "IsAccountTypeStandard"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                "",
+                {
+                  "Ref": "CurBucket"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "Resources": {
+    "IamRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "RoleName": {
+          "Ref": "RoleName"
+        },
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:${AWS::Partition}:iam::${ExternalAccount}:root"
+                }
+              },
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "sts:ExternalId": {
+                    "Ref": "ExternalId"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "CloudWatchFlowLogsPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeFlowLogs",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-CloudWatchFlowLogs-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CloudWatchLogsSpecific",
+              "Effect": "Allow",
+              "Action": [
+                "logs:GetLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:logs:*:*:*"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CloudTrailPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeCloudTrailBucket",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-CloudTrail-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CloudTrailPermissions",
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetBucketACL",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketTagging",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketNotification",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetObject",
+                "s3:List*"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${CloudTrailBucket}"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${CloudTrailBucket}/*"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "SecurityPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeSecurity",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-Security-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "SecurityPermissons",
+              "Effect": "Allow",
+              "Action": [
+                "acm:DescribeCertificate",
+                "acm:ListCertificates",
+                "acm:GetCertificate",
+                "cloudtrail:DescribeTrails",
+                "cloudtrail:GetTrailStatus",
+                "logs:GetLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "config:DescribeConfigRules",
+                "config:GetComplianceDetailsByConfigRule",
+                "config:DescribeDeliveryChannels",
+                "config:DescribeDeliveryChannelStatus",
+                "config:DescribeConfigurationRecorders",
+                "config:DescribeConfigurationRecorderStatus",
+                "ec2:Describe*",
+                "iam:Get*",
+                "iam:List*",
+                "iam:GenerateCredentialReport",
+                "kms:DescribeKey",
+                "kms:GetKeyPolicy",
+                "kms:GetKeyRotationStatus",
+                "kms:ListAliases",
+                "kms:ListGrants",
+                "kms:ListKeys",
+                "kms:ListKeyPolicies",
+                "kms:ListResourceTags",
+                "rds:Describe*",
+                "ses:ListIdentities",
+                "ses:GetSendStatistics",
+                "ses:GetIdentityDkimAttributes",
+                "ses:GetIdentityVerificationAttributes",
+                "ses:GetSendQuota",
+                "sns:GetTopicAttributes",
+                "sns:GetSubscriptionAttributes",
+                "sns:ListTopics",
+                "sns:ListSubscriptionsByTopic",
+                "sqs:ListQueues",
+                "sqs:GetQueueAttributes"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    },
+    "InventoryPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeInventory",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-Inventory-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "InventoryAndUtilization",
+              "Effect": "Allow",
+              "Action": [
+                "acm:DescribeCertificate",
+                "acm:ListCertificates",
+                "acm:GetCertificate",
+                "ec2:Describe*",
+                "ec2:GetConsoleOutput",
+                "autoscaling:Describe*",
+                "cloudformation:DescribeStacks",
+                "cloudformation:GetStackPolicy",
+                "cloudformation:GetTemplate",
+                "cloudformation:ListStackResources",
+                "cloudfront:List*",
+                "cloudfront:GetDistributionConfig",
+                "cloudfront:GetStreamingDistributionConfig",
+                "cloudhsm:Describe*",
+                "cloudhsm:List*",
+                "cloudsearch:Describe*",
+                "cloudtrail:DescribeTrails",
+                "cloudtrail:GetTrailStatus",
+                "cloudwatch:DescribeAlarms",
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics",
+                "cognito-identity:ListIdentities",
+                "cognito-identity:ListIdentityPools",
+                "cognito-idp:ListGroups",
+                "cognito-idp:ListIdentityProviders",
+                "cognito-idp:ListUserPools",
+                "cognito-idp:ListUsers",
+                "cognito-idp:ListUsersInGroup",
+                "config:DescribeConfigRules",
+                "config:GetComplianceDetailsByConfigRule",
+                "config:Describe*",
+                "datapipeline:ListPipelines",
+                "datapipeline:GetPipelineDefinition",
+                "datapipeline:DescribePipelines",
+                "directconnect:DescribeLocations",
+                "directconnect:DescribeConnections",
+                "directconnect:DescribeVirtualInterfaces",
+                "dynamodb:ListTables",
+                "dynamodb:DescribeTable",
+                "dynamodb:ListTagsOfResource",
+                "ecs:ListClusters",
+                "ecs:DescribeClusters",
+                "ecs:ListContainerInstances",
+                "ecs:DescribeContainerInstances",
+                "ecs:ListServices",
+                "ecs:DescribeServices",
+                "ecs:ListTaskDefinitions",
+                "ecs:DescribeTaskDefinition",
+                "ecs:ListTasks",
+                "ecs:DescribeTasks",
+                "ssm:ListResourceDataSync",
+                "ssm:ListAssociations",
+                "ssm:ListDocumentVersions",
+                "ssm:ListDocuments",
+                "ssm:ListInstanceAssociations",
+                "ssm:ListInventoryEntries",
+                "elasticache:Describe*",
+                "elasticache:List*",
+                "elasticbeanstalk:Describe*",
+                "elasticfilesystem:DescribeFileSystems",
+                "elasticfilesystem:DescribeTags",
+                "elasticloadbalancing:Describe*",
+                "elasticmapreduce:Describe*",
+                "elasticmapreduce:List*",
+                "es:ListDomainNames",
+                "es:DescribeElasticsearchDomains",
+                "glacier:ListTagsForVault",
+                "glacier:DescribeVault",
+                "glacier:GetVaultNotifications",
+                "glacier:DescribeJob",
+                "glacier:GetJobOutput",
+                "glacier:ListJobs",
+                "glacier:ListVaults",
+                "iam:Get*",
+                "iam:List*",
+                "iam:GenerateCredentialReport",
+                "iot:DescribeThing",
+                "iot:ListThings",
+                "kms:DescribeKey",
+                "kms:GetKeyPolicy",
+                "kms:GetKeyRotationStatus",
+                "kms:ListAliases",
+                "kms:ListGrants",
+                "kms:ListKeys",
+                "kms:ListKeyPolicies",
+                "kms:ListResourceTags",
+                "kinesis:ListStreams",
+                "kinesis:DescribeStream",
+                "kinesis:GetShardIterator",
+                "lambda:ListFunctions",
+                "lambda:ListTags",
+                "Organizations:List*",
+                "Organizations:Describe*",
+                "rds:Describe*",
+                "rds:List*",
+                "redshift:Describe*",
+                "route53:ListHealthChecks",
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets",
+                "s3:GetBucketACL",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketTagging",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketNotification",
+                "s3:GetLifecycleConfiguration",
+                "s3:List*",
+                "sdb:ListDomains",
+                "sdb:DomainMetadata",
+                "ses:ListIdentities",
+                "ses:GetSendStatistics",
+                "ses:GetIdentityDkimAttributes",
+                "ses:GetIdentityVerificationAttributes",
+                "ses:GetSendQuota",
+                "sns:GetTopicAttributes",
+                "sns:GetSubscriptionAttributes",
+                "sns:ListTopics",
+                "sns:ListSubscriptionsByTopic",
+                "sqs:ListQueues",
+                "sqs:GetQueueAttributes",
+                "storagegateway:Describe*",
+                "storagegateway:List*",
+                "support:*",
+                "swf:ListClosedWorkflowExecutions",
+                "swf:ListDomains",
+                "swf:ListActivityTypes",
+                "swf:ListWorkflowTypes",
+                "wellarchitected:List*",
+                "wellarchitected:Get*",
+                "workspaces:DescribeWorkspaceDirectories",
+                "workspaces:DescribeWorkspaceBundles",
+                "workspaces:DescribeWorkspaces"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      }
+    },
+    "DbrPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeBillingBucket",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-DBR-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CostReadDBR",
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetBucketACL",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketTagging",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketNotification",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetObject"
+              ],
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${BillingBucket}"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${BillingBucket}/*"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CurPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeCurBucket",
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ],
+        "PolicyName": "CloudCheckr-CUR-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CostReadCUR",
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${CurBucket}"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${CurBucket}/*"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "CostPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Condition": "IncludeCost",
+      "Properties": {
+        "PolicyName": "CloudCheckr-Cost-Policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "CloudCheckrCostPermissions",
+              "Action": [
+                "ce:GetReservationUtilization",
+                "ce:GetSavingsPlansPurchaseRecommendation",
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeReservedInstancesOfferings",
+                "ec2:DescribeReservedInstances",
+                "ec2:DescribeReservedInstancesListings",
+                "ec2:DescribeHostReservationOfferings",
+                "ec2:DescribeReservedInstancesModifications",
+                "ec2:DescribeHostReservations",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "ec2:DescribeRegions",
+                "ec2:DescribeKeyPairs",
+                "ec2:DescribePlacementGroups",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeSpotInstanceRequests",
+                "ec2:DescribeImages",
+                "ec2:DescribeImageAttribute",
+                "ec2:DescribeSnapshots",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeTags",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstanceAttribute",
+                "ec2:DescribeVolumeStatus",
+                "elasticache:DescribeReservedCacheNodes",
+                "elasticache:DescribeReservedCacheNodesOfferings",
+                "es:DescribeReservedElasticsearchInstances",
+                "rds:DescribeReservedDBInstances",
+                "rds:DescribeReservedDBInstancesOfferings",
+                "rds:DescribeDBInstances",
+                "redshift:DescribeReservedNodes",
+                "redshift:DescribeReservedNodeOfferings",
+                "s3:GetBucketACL",
+                "s3:GetBucketLocation",
+                "s3:GetBucketLogging",
+                "s3:GetBucketPolicy",
+                "s3:GetBucketTagging",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketNotification",
+                "s3:GetLifecycleConfiguration",
+                "s3:List*",
+                "dynamodb:DescribeReservedCapacity",
+                "dynamodb:DescribeReservedCapacityOfferings",
+                "iam:GetAccountAuthorizationDetails",
+                "iam:ListRolePolicies",
+                "iam:ListAttachedRolePolicies",
+                "savingsplans:DescribeSavingsPlans"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "IamRole"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "RoleArn": {
+      "Description": "ARN of the IAM Role",
+      "Value": {
+        "Fn::GetAtt": [
+          "IamRole",
+          "Arn"
+        ]
+      }
+    },
+    "RoleId": {
+      "Description": "Id of the IAM Role",
+      "Value": {
+        "Fn::GetAtt": [
+          "IamRole",
+          "RoleId"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses #44 of adding the CloudFormation templates related to the AWS Control Tower Integration. A future PR will include the full lambda code for the integration.